### PR TITLE
update fail test to tolerate all possible reasons for failure

### DIFF
--- a/packages/foundry/test/WrappedETH.t.sol
+++ b/packages/foundry/test/WrappedETH.t.sol
@@ -188,7 +188,7 @@ contract WrappedETHTest is Test {
         wrappedETH.transferFrom(THIS_CONTRACT,NON_CONTRACT_USER, 1 ether);
     }
 
-    function testWithdrawIsReentrancySafe() public {
+    function testFailReentrancyAttack() public {
         // Whale deposits to the WrappedETH contract
         vm.deal(NON_CONTRACT_USER, 10 ether);
         vm.prank(NON_CONTRACT_USER);
@@ -196,9 +196,9 @@ contract WrappedETHTest is Test {
         // Set up the exploit contract
         ReentrancyTest reentrancyTest = new ReentrancyTest();
         reentrancyTest.setUp{value: 1 ether}(address(wrappedETH));
-        // Hopefully this reverts, otherwise the contract is vulnerable to reentrancy
-        vm.expectRevert();
         reentrancyTest.exploitWithdraw();
+        // If the exploit worked then we should have more than we put in
+        assertGt(address(reentrancyTest).balance, 1 ether);
     }
 }
 


### PR DESCRIPTION
The test was set up to only fail when the test succeeded in a specific way. Now it will pass as long as the test fails in any way. Perhaps by a revert when `exploitWithdraw` is called or perhaps by the 'greater than' condition at the end not being met. Thanks @rin-st for reporting this!