### PR TITLE
update readme to be clear about not importing DRT token directly

### DIFF
--- a/extension/README.md.args.mjs
+++ b/extension/README.md.args.mjs
@@ -20,7 +20,7 @@ Notice the \`DecentralizedResistanceToken.sol\` contract. This contract is the E
 
 Start by defining a contract with the name \`Voting\`.
 
-The constructor should receive an address representing the "DRT" token and a uint256 representing the time period for which the vote will be open. Those parameters should set the value of state variables inside the contract for later use.
+The constructor should receive an address representing the "DRT" token and a uint256 representing the time period for which the vote will be open. Those parameters should set the value of state variables inside the contract for later use. Don't import the DRT contract directly, instead use OpenZeppelin's IERC20 interface.
 
 ---
 
@@ -32,7 +32,7 @@ The constructor should receive an address representing the "DRT" token and a uin
     ...
     constructor(address _tokenAddress, uint256 _votingPeriod) {
         // "token" and "votingDeadline" state variables should be defined somewhere in the contract
-        token = _tokenAddress;
+        token = IERC20(_tokenAddress);
         votingDeadline =  _votingPeriod;
     }
     ...


### PR DESCRIPTION
Adds a sentence pushing users towards using an ERc20 interface instead of directly importing the DRT token. The testing server has issues when it is imported like that.