### PR TITLE
Test Withdrawal Edgecase

### DIFF
--- a/extension/packages/foundry/test/EthStreaming.t.sol
+++ b/extension/packages/foundry/test/EthStreaming.t.sol
@@ -131,12 +131,32 @@ contract EthStreamingTest is Test {
     /**
      * An account that has withdrawn the full cap should not be be able to withdraw until some time has passed
      */
-    function testValidAccountExcessWithdrawalFails() public {
+    function testValidAccountCannotWithdrawFromDepletedStream() public {
         vm.startPrank(ALICE);
         // Empty Stream
         ethStreaming.withdraw(STREAM_CAP);
         vm.expectRevert();
         ethStreaming.withdraw(1);
+    }
+
+    /**
+     * An account should not be be able to withdraw more than the cap
+     */
+    function testValidAccountCannotWithdrawMoreThanCap() public {
+        vm.startPrank(ALICE);
+        vm.expectRevert();
+        ethStreaming.withdraw(STREAM_CAP * 2);
+        vm.stopPrank();
+
+        // Test edge case with second withdrawal
+        ethStreaming.addStream(BOB, STREAM_CAP);
+        vm.startPrank(BOB);
+        ethStreaming.withdraw(STREAM_CAP);
+
+        vm.warp(STARTING_TIMESTAMP + FREQUENCY * 2);
+
+        vm.expectRevert();
+        ethStreaming.withdraw(STREAM_CAP + 1);
     }
 
     /**


### PR DESCRIPTION
### Why
A bug [was reported](https://github.com/BuidlGuidl/eth-tech-tree/issues/108) in the [eth-tech-tree repo](https://github.com/BuidlGuidl/eth-tech-tree/) where a user had an implementation of the `EthStreaming.sol` contract that passed all tests, but still let accounts to withdraw more ETH than their stream cap should have allowed. Thanks @sircoderin!

### How
- Adds an extra test, `testValidAccountCannotWithdrawMoreThanCap`, to cover the missing edgecase (that was only possible on an account's second withdrawal)
- Renames `testValidAccountExcessWithdrawalFails` => `testValidAccountCannotWithdrawFromDepletedStream` to make clear that it has a different purpose than the newly added test.