### PR TITLE
update wording on getResult

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ You can find the number of votes to remove by checking their token balance as th
 ### Step 6
 The last step is we need to be able to call a function to get the result of the vote.
 
-Define a function called `getResult` that receives a uint representing the proposal id for which you want the result.
+Define a view function called `getResult` that receives a uint representing the proposal id for which you want the result.
 
 This function should revert if the vote period is not over yet. It should return true or false depending on whether a simple majority is reached:`votesFor > votesAgainst`. Abstaining votes have no effect on the outcome.
 

--- a/extension/README.md.args.mjs
+++ b/extension/README.md.args.mjs
@@ -113,7 +113,7 @@ You can find the number of votes to remove by checking their token balance as th
 ### Step 6
 The last step is we need to be able to call a function to get the result of the vote.
 
-Define a function called \`getResult\` that receives a uint representing the proposal id for which you want the result.
+Define a view function called \`getResult\` that receives a uint representing the proposal id for which you want the result.
 
 This function should revert if the vote period is not over yet. It should return true or false depending on whether a simple majority is reached:\`votesFor > votesAgainst\`. Abstaining votes have no effect on the outcome.
 


### PR DESCRIPTION
User reported a test failure (only when running tests on server) due to them doing a state change in this function. I researched for a simple way to verify no state change occurred and decided against implementing anything as it looks extensive and problematic.